### PR TITLE
Fixed javascript include file name

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -18,7 +18,7 @@
 	<!-- <script src="scale.raphael.js"></script> -->
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.js"></script>
 	<script src="color.jquery.js"></script>
-	<script src="../us-map.js"></script>
+	<script src="../jquery.usmap.js"></script>
 	
 	<script>
 	$(document).ready(function() {


### PR DESCRIPTION
The javascript file included in the example header did not match the
actual physical file name, this commit corrects this.